### PR TITLE
Update sabnzbd and par2cmdline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM hypriot/rpi-alpine:latest
 MAINTAINER Cameron Meindl <cmeindl@gmail.com>
-ARG GITTAG=2.1.0
+ARG GITTAG=2.3.x
 ARG PAR2TAG=v0.6.14
 
 RUN buildDeps="gcc g++ git mercurial make automake autoconf python-dev openssl-dev libffi-dev musl-dev" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM hypriot/rpi-alpine:latest
 MAINTAINER Cameron Meindl <cmeindl@gmail.com>
 ARG GITTAG=2.3.x
-ARG PAR2TAG=v0.6.14
+ARG PAR2TAG=v0.8.0
 
 RUN buildDeps="gcc g++ git mercurial make automake autoconf python-dev openssl-dev libffi-dev musl-dev" \
   && apk --update add $buildDeps \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM hypriot/rpi-alpine:latest
 MAINTAINER Cameron Meindl <cmeindl@gmail.com>
-ARG GITTAG=2.3.x
+ARG GITTAG=master
 ARG PAR2TAG=v0.8.0
 
 RUN buildDeps="gcc g++ git mercurial make automake autoconf python-dev openssl-dev libffi-dev musl-dev" \


### PR DESCRIPTION
Now pulls the master branch (which is recommended by sabnbzd, the version tags should not be used for end-users.

> ```master``` contains only stable releases (which have been merged to master) and is intended for end-users.

The par2cmdline version is almost 3 years old and should be updated. 0.7.0 also added multicore par, but somehow sabnzbd doesnt detect it properly for me.
I did'nt run into any issues with the new version.